### PR TITLE
fix: consider overflow-y: scroll as overflowing in isBodyOverflowing

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,9 @@
  * Test usage export. Do not use in your production
  */
 export function isBodyOverflowing() {
+  if (window.getComputedStyle(document.body).overflowY === 'scroll')
+    return true;
+
   return (
     document.body.scrollHeight >
       (window.innerHeight || document.documentElement.clientHeight) &&


### PR DESCRIPTION
When the body has `overflow-y: scroll` set, the scrollbar is always visible,
even if the content doesn’t overflow. Previously, `isBodyOverflowing`
returned false in this case, causing layout shifts (e.g., modal jumps)
because no padding was applied.

This change makes `isBodyOverflowing` return true if `overflow-y: scroll`
is detected, ensuring consistent scrollbar handling and preventing UI jumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了页面在 body 的 overflowY 样式为 'scroll' 时无法正确检测溢出的问题，提升了溢出判断的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->