### PR TITLE
fix: maximum updates Portal.tsx

### DIFF
--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -91,16 +91,12 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
     const customizeContainer = getPortalContainer(getContainer);
 
     // Tell component that we check this in effect which is safe to be `null`
-    setInnerContainer((prev) => {
-      const nextContainer = customizeContainer ?? null;
-  
-      // Avoid cascading updates when the target container is unchanged
-      if (prev === nextContainer) {
-        return prev;
-      }
-  
-      return nextContainer;
-    });
+    setInnerContainer(
+      () =>
+        // React do the state update even the value is the same,
+        // Use function call to force React to compare update
+        customizeContainer ?? null,
+    );
   });
 
   const [defaultContainer, queueCreate] = useDom(

--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -91,7 +91,16 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
     const customizeContainer = getPortalContainer(getContainer);
 
     // Tell component that we check this in effect which is safe to be `null`
-    setInnerContainer(customizeContainer ?? null);
+    setInnerContainer((prev) => {
+      const nextContainer = customizeContainer ?? null;
+  
+      // Avoid cascading updates when the target container is unchanged
+      if (prev === nextContainer) {
+        return prev;
+      }
+  
+      return nextContainer;
+    });
   });
 
   const [defaultContainer, queueCreate] = useDom(

--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -101,7 +101,7 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
   
       return nextContainer;
     });
-  });
+  }, [getContainer]);
 
   const [defaultContainer, queueCreate] = useDom(
     mergedRender && !innerContainer,

--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -101,7 +101,7 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
   
       return nextContainer;
     });
-  }, [getContainer]);
+  });
 
   const [defaultContainer, queueCreate] = useDom(
     mergedRender && !innerContainer,


### PR DESCRIPTION
Fix for the following error:
error-boundary-callbacks.ts:80 Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
    at getRootForUpdatedFiber (react-dom-client.development.js:3860:11)
    at enqueueConcurrentHookUpdate (react-dom-client.development.js:3820:14)
    at dispatchSetStateInternal (react-dom-client.development.js:8121:18)
    at dispatchSetState (react-dom-client.development.js:8081:7)
    at Portal.useEffect (Portal.js:63:5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能优化**
  * 调整容器更新策略：即便目标容器值相同也会触发一次更新，确保在容器来源变化时能正确重新应用并避免遗漏刷新，提升可靠性与响应性。
  * 保留自定义容器行为，未更改任何对外公开接口或导出签名。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->