### PR TITLE
feat: add CSP nonce support to Portal

### DIFF
--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -40,6 +40,8 @@ export interface PortalProps {
   /** Lock screen scroll when open */
   autoLock?: boolean;
   onEsc?: EscCallback;
+  /** Nonce for Content Security Policy */
+  nonce?: string;
 
   /** @private debug name. Do not use in prod */
   debug?: string;
@@ -72,6 +74,7 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
     autoDestroy = true,
     children,
     onEsc,
+    nonce,
   } = props;
 
   const [shouldRender, setShouldRender] = React.useState(open);
@@ -117,13 +120,14 @@ const Portal = React.forwardRef<any, PortalProps>((props, ref) => {
   const mergedContainer = innerContainer ?? defaultContainer;
 
   // ========================= Locker ==========================
-  useScrollLocker(
+  const shouldLock =
     autoLock &&
-      open &&
-      canUseDom() &&
-      (mergedContainer === defaultContainer ||
-        mergedContainer === document.body),
-  );
+    open &&
+    canUseDom() &&
+    (mergedContainer === defaultContainer ||
+      mergedContainer === document.body);
+
+  useScrollLocker({ lock: shouldLock, nonce });
 
   // ========================= Esc Keydown ==========================
   useEscKeyDown(open, onEsc);

--- a/src/useScrollLocker.tsx
+++ b/src/useScrollLocker.tsx
@@ -8,8 +8,18 @@ const UNIQUE_ID = `rc-util-locker-${Date.now()}`;
 
 let uuid = 0;
 
-export default function useScrollLocker(lock?: boolean) {
-  const mergedLock = !!lock;
+export interface UseScrollLockerOptions {
+  lock?: boolean;
+  nonce?: string;
+}
+
+export default function useScrollLocker(
+  lock?: boolean | UseScrollLockerOptions,
+) {
+  const options = typeof lock === 'object' ? lock : { lock };
+  const mergedLock = !!(typeof lock === 'boolean' ? lock : options.lock);
+  const nonce = typeof lock === 'object' ? lock.nonce : undefined;
+
   const [id] = React.useState(() => {
     uuid += 1;
     return `${UNIQUE_ID}_${uuid}`;
@@ -27,6 +37,9 @@ html body {
   ${isOverflow ? `width: calc(100% - ${scrollbarSize}px);` : ''}
 }`,
         id,
+        {
+          csp: nonce ? { nonce } : undefined,
+        },
       );
     } else {
       removeCSS(id);
@@ -35,5 +48,5 @@ html body {
     return () => {
       removeCSS(id);
     };
-  }, [mergedLock, id]);
+  }, [mergedLock, id, nonce]);
 }


### PR DESCRIPTION
- Add nonce prop to Portal component for Content Security Policy compliance
- Update useScrollLocker to accept nonce option for dynamic style injection
- Refactor useScrollLocker to support both boolean and options object parameter
- Add comprehensive test coverage for nonce functionality
- Maintain backward compatibility with existing boolean parameter usage

This enables Portal to work in strict CSP environments by allowing developers to pass a nonce attribute for dynamically injected styles used in scroll locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * Portal 组件现已支持 `nonce` 属性，增强安全集成能力。
  * useScrollLocker 钩子扩展支持配置对象参数。

* **测试**
  * 新增 nonce 功能的完整测试套件，覆盖自动锁定、自定义容器和边界情况等场景。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->