### PR TITLE
chore: forbid rc deep imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,29 @@
+const restrictedPackageDirectoryImports = [
+  '@rc-component/*/es',
+  '@rc-component/*/es/**',
+  '@rc-component/*/lib',
+  '@rc-component/*/lib/**',
+  'rc-*/es',
+  'rc-*/es/**',
+  'rc-*/lib',
+  'rc-*/lib/**',
+];
+
 const config = {
   extends: [require.resolve('@umijs/fabric/dist/eslint')],
   rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: restrictedPackageDirectoryImports,
+            message:
+              'Do not import package internals from es/lib. Import from the package root.',
+          },
+        ],
+      },
+    ],
     'react/no-did-update-set-state': 0,
     'react/no-find-dom-node': 0,
     'import/no-extraneous-dependencies': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,6 @@
-const restrictedPackageDirectoryImports = [
-  '@rc-component/*/es',
-  '@rc-component/*/es/**',
-  '@rc-component/*/lib',
-  '@rc-component/*/lib/**',
-  'rc-*/es',
-  'rc-*/es/**',
-  'rc-*/lib',
-  'rc-*/lib/**',
-];
-
 const config = {
   extends: [require.resolve('@umijs/fabric/dist/eslint')],
   rules: {
-    'no-restricted-imports': [
-      'error',
-      {
-        patterns: [
-          {
-            group: restrictedPackageDirectoryImports,
-            message:
-              'Do not import package internals from es/lib. Import from the package root.',
-          },
-        ],
-      },
-    ],
     'react/no-did-update-set-state': 0,
     'react/no-find-dom-node': 0,
     'import/no-extraneous-dependencies': 0,

--- a/package.json
+++ b/package.json
@@ -44,14 +44,15 @@
     "watch": "father dev"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.2",
     "@rc-component/np": "^1.0.3",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.0",
-    "@testing-library/react": "^13.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/jest": "^26.0.20",
     "@types/node": "^20.9.0",
     "@types/react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.0",

--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -1,10 +1,10 @@
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
 import {
+  canUseDom,
   getNodeRef,
   supportRef,
   useComposeRef,
-} from '@rc-component/util/lib/ref';
-import warning from '@rc-component/util/lib/warning';
+  warning,
+} from '@rc-component/util';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import OrderContext from './Context';

--- a/src/useDom.tsx
+++ b/src/useDom.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom, useLayoutEffect } from '@rc-component/util';
 import OrderContext from './Context';
 import type { QueueCreate } from './Context';
 

--- a/src/useEscKeyDown.ts
+++ b/src/useEscKeyDown.ts
@@ -1,5 +1,4 @@
-import { useEvent } from '@rc-component/util';
-import useId from '@rc-component/util/lib/hooks/useId';
+import { useEvent, useId } from '@rc-component/util';
 import { useEffect, useMemo } from 'react';
 import { type EscCallback } from './Portal';
 

--- a/src/useScrollLocker.tsx
+++ b/src/useScrollLocker.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { updateCSS, removeCSS } from '@rc-component/util/lib/Dom/dynamicCSS';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import { getTargetScrollBarSize } from '@rc-component/util/lib/getScrollBarSize';
+import {
+  getTargetScrollBarSize,
+  removeCSS,
+  updateCSS,
+  useLayoutEffect,
+} from '@rc-component/util';
 import { isBodyOverflowing } from './util';
 
 const UNIQUE_ID = `rc-util-locker-${Date.now()}`;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -13,15 +13,15 @@ jest.mock('../src/util', () => {
   };
 });
 
-// Revert `useLayoutEffect` back to real one since we should keep order for test
-jest.mock('@rc-component/util/lib/hooks/useLayoutEffect', () => {
-  const origin = jest.requireActual('react');
-  return origin.useLayoutEffect;
-});
-
-jest.mock('@rc-component/util/lib/hooks/useId', () => {
-  const origin = jest.requireActual('react');
-  return origin.useId;
+jest.mock('@rc-component/util', () => {
+  const origin = jest.requireActual('@rc-component/util');
+  const React = jest.requireActual('react');
+  return {
+    ...origin,
+    // Revert `useLayoutEffect` back to real one since we should keep order for test
+    useLayoutEffect: React.useLayoutEffect,
+    useId: React.useId,
+  };
 });
 
 describe('Portal', () => {

--- a/tests/webkit.test.tsx
+++ b/tests/webkit.test.tsx
@@ -10,18 +10,13 @@ jest.mock('../src/util', () => {
   };
 });
 
-// Revert `useLayoutEffect` back to real one since we should keep order for test
-jest.mock('@rc-component/util/lib/hooks/useLayoutEffect', () => {
-  const origin = jest.requireActual('react');
-  return origin.useLayoutEffect;
-});
-
-// Revert `useLayoutEffect` back to real one since we should keep order for test
-jest.mock('@rc-component/util/lib/getScrollBarSize', () => {
-  const origin = jest.requireActual('@rc-component/util/lib/getScrollBarSize');
+jest.mock('@rc-component/util', () => {
+  const origin = jest.requireActual('@rc-component/util');
+  const React = jest.requireActual('react');
   return {
     ...origin,
-
+    // Revert `useLayoutEffect` back to real one since we should keep order for test
+    useLayoutEffect: React.useLayoutEffect,
     getTargetScrollBarSize: () => ({ width: 93, height: 1128 }),
   };
 });


### PR DESCRIPTION
## 背景

antd 6.4.x 相关场景下，Yarn PnP、Vite、Vitest、Node 25 可能直接加载 rc 包的 es/lib 构建产物内部路径，从而触发 ES module 加载问题。rc 包之间不应依赖其他包的构建产物内部路径。

## 变更内容

- 添加 no-restricted-imports 规则，禁止 @rc-component/* 和 rc-* 的 es/lib 深路径导入。
- 将 @rc-component/util 深路径导入替换为包根入口导入，并将依赖升级到 ^1.11.0。
- 调整测试 mock，避免继续依赖 @rc-component/util 内部路径。
- 升级 @testing-library/react 并补充 @testing-library/dom，用于兼容 React 19 下的安装解析。

## 验证

- npm install --package-lock=false
- npm run lint
- npm run lint:tsc
- npm run compile
- npm run test

说明：lint 和 compile 仍会输出现有 react-hooks/exhaustive-deps warning；测试中仍会输出已有的 React.Fragment ref console.error，但命令退出码均为 0。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 升级依赖版本：`@rc-component/util` 至 `^1.11.0`，`@testing-library/react` 至 `^16.3.2`
  * 优化模块导入结构，统一来源于包的主入口
  * 更新代码检查规则以约束导入路径
  * 调整测试配置以确保稳定性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/portal/pull/36)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->